### PR TITLE
ublox.conf: Fix "PS attached" when roaming

### DIFF
--- a/etc/moxa-cellular-utils/module.d/ublox.conf
+++ b/etc/moxa-cellular-utils/module.d/ublox.conf
@@ -338,8 +338,9 @@ _module_05c6_90b2_attach_status() {
 
 	#  According to TS 27.007 definition
 	# +CEREG: <n>,<stat>: stat=1 registered, home network.
+	# +CEREG: <n>,<stat>: stat=5 registered, roaming.
 	status=$(cell_at_cmd "AT+CEREG?" | grep "^+CEREG:" | cut -d ',' -f 2)
-	[ -n "${status}" ] && [ "${status}" = "1" ] && ps="attached"
+	[ -n "${status}" ] && ([ "${status}" = "1" ] || [ "${status}" = "5" ]) && ps="attached"
 	# +CREG: 0,1
 	# For the circuit switch. 1 means registered.
 	status=$(cell_at_cmd "AT+CREG?" | grep "^+CREG" | cut -d ',' -f 2)


### PR DESCRIPTION
Hello,

Got a problem when using IoT SIM card: those cards are not from a specific network provider. As a result they are ALWAYS roaming.

Existing code only considers "PS attached" when SIM card is in home network (code 1), not roaming (code 5). I've added code 5  to say "atttached" when roaming.

If not, command `sudo cell_mgmt start` fails and cannot get connection.

I only modify this file because my UC-2100 uses this particular modem. This Moxa model is discontinued, I hope the UC-3100 I should receive soon is using this same modem. Maybe you should see if for other modems the "roaming" option is considered.

CODES
---------
From ublox documentation: https://content.u-blox.com/sites/default/files/SARA-R4_ATCommands_UBX-17003787.pdf
Page 187, chapter 13.14.4:

```
<stat> Number EPS registration status:
• 0: not registered
• 1: registered, home network
• 2: not registered, but the MT is currently trying to attach or searching an operator
to register to
• 3: registration denied
• 4: unknown (e.g. out of E-UTRAN coverage)
• 5: registered, roaming
• 8: attached for emergency bearer services only (see 3GPP TS 24.008 [82] and 3GPP
TS 24.301 [117] that specify the condition when the MS is considered as attached
for emergency bearer services)
```
